### PR TITLE
FCOM-171 tiketin mukaisesti NewtonSoft nugetin downgrade

### DIFF
--- a/Frends.Community.StaticStorage.Tests/Frends.Community.StaticStorage.Tests.csproj
+++ b/Frends.Community.StaticStorage.Tests/Frends.Community.StaticStorage.Tests.csproj
@@ -44,8 +44,8 @@
     <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\MSTest.TestFramework.1.1.18\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.11.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.10.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/Frends.Community.StaticStorage.Tests/packages.config
+++ b/Frends.Community.StaticStorage.Tests/packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="MSTest.TestAdapter" version="1.1.18" targetFramework="net452" />
   <package id="MSTest.TestFramework" version="1.1.18" targetFramework="net452" />
-  <package id="Newtonsoft.Json" version="11.0.1" targetFramework="net452" />
+  <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
FCOM-171 tiketin mukaisesti NewtonSoft nugetin downgrade 11.0.2 -> 10.0.2 versioon, jotta nugetit ovat testissä ja taskissa sama.